### PR TITLE
Add workflow for publishing the package to the npm registory

### DIFF
--- a/.github/workflows/pr-builder.yml
+++ b/.github/workflows/pr-builder.yml
@@ -5,6 +5,7 @@ name: PR Builder
 on:
   pull_request:
     branches: [ main ]
+  workflow_dispatch:  
 
 jobs:
   build:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,45 @@
+# This workflow builds the project and it'll cut a patch tag and will publish the changes to the npm registry.
+
+name: Publish
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [12.x]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2.3.3
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2.1.2
+        with:
+          node-version: ${{ matrix.node-version }}
+          registry-url: https://registry.npmjs.org/
+
+      - name: Build
+        run: |
+          npm ci
+          npm run build --if-present
+
+      - name: Bump version
+        run: |
+          git config --global user.email "version.bump@github.action.com"
+          git config --global user.name "github-actions-bot"
+          npm version patch -m "[WSO2 Release] [GitHub Actions $(github.run_number)] [Release %s] prepare release %s"
+          git push --follow-tags
+
+      - name: Publish to NPM
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+        run: |
+          npm publish --access public

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,7 +5,7 @@ name: Publish
 on:
   push:
     branches:
-      - master
+      - [ main ]
 
 jobs:
   build:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,6 +6,7 @@ on:
   push:
     branches:
       - [ main ]
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,13 +32,6 @@ jobs:
           npm ci
           npm run build --if-present
 
-      - name: Bump version
-        run: |
-          git config --global user.email "version.bump@github.action.com"
-          git config --global user.name "github-actions-bot"
-          npm version patch -m "[WSO2 Release] [GitHub Actions $(github.run_number)] [Release %s] prepare release %s"
-          git push --follow-tags
-
       - name: Publish to NPM
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/package.json
+++ b/package.json
@@ -37,5 +37,13 @@
         "rimraf": "^3.0.2",
         "run-script-os": "^1.0.7",
         "typescript": "^4.0.2"
-    }
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/wso2/identity-cypress-test-base.git"
+    },
+    "bugs": {
+        "url": "https://github.com/wso2/identity-cypress-test-base/issues"
+    },
+    "homepage": "https://github.com/wso2/identity-cypress-test-base#readme"
 }


### PR DESCRIPTION
## Purpose
The package should be published to npm when new code changes are merged to the `main` branch.

## Goals
This PR adds a GitHub action to trigger a workflow for publishing the module to `npm`.

## Approach
The workflow will go through the following lifecycles.
1. Build the project.
2. Bump the version (to a patch version)
3. Publish to the npm registry.
