### PR TITLE
Add abstract page object classes for listing and wizard

### DIFF
--- a/src/ui/commands/dom.ts
+++ b/src/ui/commands/dom.ts
@@ -24,9 +24,15 @@ import { CommonUtils } from "../utils";
 /**
  * Custom command to select DOM element by data-testid attribute.
  *
+ * @example
+ *    cy.dataTestId("<RAW_TEST_ID>") -> [data-testid=<RAW_TEST_ID>]
+ *
  * @param {string} value - Attribute value.
+ * @param {string} options - Attribute value.
  * @returns {Cypress.CanReturnChainable}
  */
-Cypress.Commands.add("dataTestId", (value: string): Cypress.CanReturnChainable => {
-    return cy.get(CommonUtils.resolveDataTestId(value));
+Cypress.Commands.add("dataTestId", (value: string, options?: Partial<Cypress.Loggable & Cypress.Timeoutable
+    & Cypress.Withinable & Cypress.Shadow>): Cypress.CanReturnChainable => {
+
+    return cy.get(CommonUtils.resolveDataTestId(value), options);
 });

--- a/src/ui/commands/user-onboard/commands.ts
+++ b/src/ui/commands/user-onboard/commands.ts
@@ -31,10 +31,10 @@ Cypress.Commands.add("navigateToUserManagement", (switchPortalTab: boolean = tru
 
     if (switchPortalTab) {
         const header: ConsoleHeader = new ConsoleHeader();
-        header.clickOnManagePortalSwitch();
+        header.clickOnManagePortalSwitch({ force: true });
     }
 
     const sidePanel: ConsoleSidePanel = new ConsoleSidePanel();
 
-    sidePanel.navigateToUsers();
+    sidePanel.navigateToUsers({ force: true });
 });

--- a/src/ui/page-objects/console/console-header.ts
+++ b/src/ui/page-objects/console/console-header.ts
@@ -29,15 +29,17 @@ export class ConsoleHeader extends Header {
 
     /**
      * Click on the developer portal switch.
+     * @param {Partial<ClickOptions>} options - Click options.
      */
-    public clickOnDevelopPortalSwitch(): void {
+    public clickOnDevelopPortalSwitch(options?: Partial<Cypress.ClickOptions>): void {
         cy.dataTestId(ConsoleHeaderDomConstants.DEVELOP_SWITCH_DATA_ATTR).click();
     }
 
     /**
      * Click on the manage portal switch.
+     * @param {Partial<ClickOptions>} options - Click options.
      */
-    public clickOnManagePortalSwitch(): void {
+    public clickOnManagePortalSwitch(options?: Partial<Cypress.ClickOptions>): void {
         cy.dataTestId(ConsoleHeaderDomConstants.MANAGE_SWITCH_DATA_ATTR).click();
     }
 }

--- a/src/ui/page-objects/console/create-wizard.ts
+++ b/src/ui/page-objects/console/create-wizard.ts
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+/// <reference types="cypress" />
+
+/**
+ * Abstract Class containing common create wizard objects.
+ */
+export abstract class CreateWizard {
+
+    /**
+     * Get the creation wizard.
+     * @return {Cypress.Chainable<Element>}
+     */
+    public abstract getCreateWizard(): Cypress.Chainable<Element>;
+
+    /**
+     * Get the minimal creation wizard form submit button.
+     * @return {Cypress.Chainable<Element>}
+     */
+    public abstract getCreateWizardSubmitButton(): Cypress.Chainable<Element>;
+
+    /**
+     * Get the creation wizard success alert.
+     * @return {Cypress.Chainable<Element>}
+     */
+    public abstract getCreateWizardSuccessAlert(): Cypress.Chainable<Element>;
+
+    /**
+     * Get the creation wizard error alert.
+     * @return {Cypress.Chainable<Element>}
+     */
+    public abstract getCreateWizardErrorAlert(): Cypress.Chainable<Element>;
+
+    /**
+     * Click on the creation wizard form submit button.
+     * @param {Partial<ClickOptions>} options - Click options.
+     */
+    public clickOnCreateWizardSubmitButton(options?: Partial<Cypress.ClickOptions>): void {
+        this.getCreateWizardSubmitButton().click(options);
+    }
+}

--- a/src/ui/page-objects/console/index.ts
+++ b/src/ui/page-objects/console/index.ts
@@ -18,4 +18,6 @@
  */
 
 export * from "./console-header";
+export * from "./create-wizard";
+export * from "./list-page";
 export * from "./side-panel";

--- a/src/ui/page-objects/console/list-page.ts
+++ b/src/ui/page-objects/console/list-page.ts
@@ -1,0 +1,132 @@
+/**
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+
+/// <reference types="cypress" />
+
+/**
+ * Abstract Class containing common listing page objects.
+ */
+export abstract class ListPage {
+
+    /**
+     * Get the table element.
+     * @return {Cypress.Chainable<Element>}
+     */
+    public abstract getTable(): Cypress.Chainable<Element>;
+
+    /**
+     * Get the table body element.
+     * @return {Cypress.Chainable<Element>}
+     */
+    public abstract getTableBody(): Cypress.Chainable<Element>;
+
+    /**
+     * Get the table first element.
+     * @return {Cypress.Chainable<Element>}
+     */
+    public getTableFirstElement(): Cypress.Chainable<Element> {
+        return this.getTable()
+            .within(() => {
+                cy.dataTestId("data-table-row")
+                    .eq(0);
+            });
+    }
+
+    /**
+     * Click on the table first element's edit button.
+     */
+    public clickOnTableFirstElementEditButton(): void {
+        this.getTableFirstElement()
+            .within(() => {
+                this.getTableItemEditButton().trigger("mouseover").click();
+            });
+    }
+
+    /**
+     * Click on the table first element's view button.
+     */
+    public clickOnTableFirstElementViewButton(): void {
+        this.getTableFirstElement()
+            .within(() => {
+                this.getTableItemViewButton().trigger("mouseover").click();
+            });
+    }
+
+    /**
+     * Get the the table item heading.
+     * @return {Cypress.Chainable<Element>}
+     */
+    public abstract getTableItemHeading(): Cypress.Chainable<Element>;
+
+    /**
+     * Get the the table item edit button.
+     * @return {Cypress.Chainable<Element>}
+     */
+    public abstract getTableItemEditButton(): Cypress.Chainable<Element>;
+
+    /**
+     * Get the the table item delete button.
+     * @return {Cypress.Chainable<Element>}
+     */
+    public abstract getTableItemViewButton(): Cypress.Chainable<Element>;
+
+    /**
+     * Get the page layout header element.
+     * @return {Cypress.Chainable<Element>}
+     */
+    public abstract getPageLayoutHeader(): Cypress.Chainable<Element>;
+
+    /**
+     * Get the page layout header title element.
+     * @return {Cypress.Chainable<Element>}
+     */
+    public abstract getPageLayoutHeaderTitle(): Cypress.Chainable<Element>;
+
+    /**
+     * Get the page layout header sub title element.
+     * @return {Cypress.Chainable<Element>}
+     */
+    public abstract getPageLayoutHeaderSubTitle(): Cypress.Chainable<Element>;
+
+    /**
+     * Get the page layout header action element.
+     * @return {Cypress.Chainable<Element>}
+     */
+    public abstract getPageLayoutHeaderAction(): Cypress.Chainable<Element>;
+
+    /**
+     * Get the list new placeholder element.
+     * @return {Cypress.Chainable<Element>}
+     */
+    public abstract getNewTablePlaceholder(): Cypress.Chainable<Element>;
+
+    /**
+     * Get the list new placeholder action element.
+     * @return {Cypress.Chainable<Element>}
+     */
+    public abstract getNewTablePlaceholderAction(): Cypress.Chainable<JQuery<HTMLButtonElement>>;
+
+    /**
+     * Click on the new button.
+     * @param {Partial<ClickOptions>} options - Click options.
+     */
+    public clickOnNewButton(options?: Partial<Cypress.ClickOptions>): void {
+        this.getPageLayoutHeaderAction().click(options);
+    }
+}

--- a/src/ui/page-objects/console/side-panel.ts
+++ b/src/ui/page-objects/console/side-panel.ts
@@ -28,97 +28,97 @@ export class ConsoleSidePanel {
 
     /**
      * Click on Applications feature from side panel.
-     * @return {Cypress.Chainable<Element>}
+     * @param {Partial<ClickOptions>} options - Click options.
      */
-    public navigateToApplications(): Cypress.Chainable<Element> {
-        return cy.dataTestId(ConsoleSidePanelDomConstants.APPLICATIONS_MENU_ITEM_DATA_ATTR).click();
+    public navigateToApplications(options?: Partial<Cypress.ClickOptions>): void {
+        cy.dataTestId(ConsoleSidePanelDomConstants.APPLICATIONS_MENU_ITEM_DATA_ATTR).click();
     }
 
     /**
      * Click on IDP feature from side panel.
-     * @return {Cypress.Chainable<Element>}
+     * @param {Partial<ClickOptions>} options - Click options.
      */
-    public navigateToIdentityProviders(): Cypress.Chainable<Element> {
-        return cy.dataTestId(ConsoleSidePanelDomConstants.IDP_MENU_ITEM_DATA_ATTR).click();
+    public navigateToIdentityProviders(options?: Partial<Cypress.ClickOptions>): void {
+        cy.dataTestId(ConsoleSidePanelDomConstants.IDP_MENU_ITEM_DATA_ATTR).click();
     }
 
     /**
      * Click on Users feature from side panel.
-     * @return {Cypress.Chainable<Element>}
+     * @param {Partial<ClickOptions>} options - Click options.
      */
-    public navigateToUsers(): Cypress.Chainable<Element> {
-        return cy.dataTestId(ConsoleSidePanelDomConstants.USERS_MENU_ITEM_DATA_ATTR).click();
+    public navigateToUsers(options?: Partial<Cypress.ClickOptions>): void {
+        cy.dataTestId(ConsoleSidePanelDomConstants.USERS_MENU_ITEM_DATA_ATTR).click();
     }
 
     /**
      * Click on Groups feature from side panel.
-     * @return {Cypress.Chainable<Element>}
+     * @param {Partial<ClickOptions>} options - Click options.
      */
-    public navigateToGroups(): Cypress.Chainable<Element> {
-        return cy.dataTestId(ConsoleSidePanelDomConstants.GROUPS_MENU_ITEM_DATA_ATTR).click();
+    public navigateToGroups(options?: Partial<Cypress.ClickOptions>): void {
+        cy.dataTestId(ConsoleSidePanelDomConstants.GROUPS_MENU_ITEM_DATA_ATTR).click();
     }
 
     /**
      * Click on Roles feature from side panel.
-     * @return {Cypress.Chainable<Element>}
+     * @param {Partial<ClickOptions>} options - Click options.
      */
-    public navigateToRoles(): Cypress.Chainable<Element> {
-        return cy.dataTestId(ConsoleSidePanelDomConstants.ROLES_MENU_ITEM_DATA_ATTR).click();
+    public navigateToRoles(options?: Partial<Cypress.ClickOptions>): void {
+        cy.dataTestId(ConsoleSidePanelDomConstants.ROLES_MENU_ITEM_DATA_ATTR).click();
     }
 
     /**
      * Click on Userstores feature from side panel.
-     * @return {Cypress.Chainable<Element>}
+     * @param {Partial<ClickOptions>} options - Click options.
      */
-    public navigateToUserstores(): Cypress.Chainable<Element> {
-        return cy.dataTestId(ConsoleSidePanelDomConstants.USERSTORES_MENU_ITEM_DATA_ATTR).click();
+    public navigateToUserstores(options?: Partial<Cypress.ClickOptions>): void {
+        cy.dataTestId(ConsoleSidePanelDomConstants.USERSTORES_MENU_ITEM_DATA_ATTR).click();
     }
 
     /**
      * Click on Certificates feature from side panel.
-     * @return {Cypress.Chainable<Element>}
+     * @param {Partial<ClickOptions>} options - Click options.
      */
-    public navigateToCertificates(): Cypress.Chainable<Element> {
-        return cy.dataTestId(ConsoleSidePanelDomConstants.CERTIFICATES_MENU_ITEM_DATA_ATTR).click();
+    public navigateToCertificates(options?: Partial<Cypress.ClickOptions>): void {
+        cy.dataTestId(ConsoleSidePanelDomConstants.CERTIFICATES_MENU_ITEM_DATA_ATTR).click();
     }
 
     /**
      * Click on Attributes feature from side panel.
-     * @return {Cypress.Chainable<Element>}
+     * @param {Partial<ClickOptions>} options - Click options.
      */
-    public navigateToAttributes(): Cypress.Chainable<Element> {
-        return cy.dataTestId(ConsoleSidePanelDomConstants.ATTRIBUTES_MENU_ITEM_DATA_ATTR).click();
+    public navigateToAttributes(options?: Partial<Cypress.ClickOptions>): void {
+        cy.dataTestId(ConsoleSidePanelDomConstants.ATTRIBUTES_MENU_ITEM_DATA_ATTR).click();
     }
 
     /**
      * Click on Dialects feature from side panel.
-     * @return {Cypress.Chainable<Element>}
+     * @param {Partial<ClickOptions>} options - Click options.
      */
-    public navigateToDialects(): Cypress.Chainable<Element> {
-        return cy.dataTestId(ConsoleSidePanelDomConstants.DIALECTS_MENU_ITEM_DATA_ATTR).click();
+    public navigateToDialects(options?: Partial<Cypress.ClickOptions>): void {
+        cy.dataTestId(ConsoleSidePanelDomConstants.DIALECTS_MENU_ITEM_DATA_ATTR).click();
     }
 
     /**
      * Click on OIDC Scopes feature from side panel.
-     * @return {Cypress.Chainable<Element>}
+     * @param {Partial<ClickOptions>} options - Click options.
      */
-    public navigateToOIDCScopes(): Cypress.Chainable<Element> {
-        return cy.dataTestId(ConsoleSidePanelDomConstants.OIDC_SCOPES_MENU_ITEM_DATA_ATTR).click();
+    public navigateToOIDCScopes(options?: Partial<Cypress.ClickOptions>): void {
+        cy.dataTestId(ConsoleSidePanelDomConstants.OIDC_SCOPES_MENU_ITEM_DATA_ATTR).click();
     }
 
     /**
      * Click on Email Templates feature from side panel.
-     * @return {Cypress.Chainable<Element>}
+     * @param {Partial<ClickOptions>} options - Click options.
      */
-    public navigateToEmailTemplates(): Cypress.Chainable<Element> {
-        return cy.dataTestId(ConsoleSidePanelDomConstants.EMAIL_TEMPLATES_MENU_ITEM_DATA_ATTR).click();
+    public navigateToEmailTemplates(options?: Partial<Cypress.ClickOptions>): void {
+        cy.dataTestId(ConsoleSidePanelDomConstants.EMAIL_TEMPLATES_MENU_ITEM_DATA_ATTR).click();
     }
 
     /**
      * Click on Remote Fetch feature from side panel.
-     * @return {Cypress.Chainable<Element>}
+     * @param {Partial<ClickOptions>} options - Click options.
      */
-    public navigateToRemoteFetch(): Cypress.Chainable<Element> {
-        return cy.dataTestId(ConsoleSidePanelDomConstants.REMOTE_FETCH_MENU_ITEM_DATA_ATTR).click();
+    public navigateToRemoteFetch(options?: Partial<Cypress.ClickOptions>): void {
+        cy.dataTestId(ConsoleSidePanelDomConstants.REMOTE_FETCH_MENU_ITEM_DATA_ATTR).click();
     }
 }

--- a/types/ui/commands.d.ts
+++ b/types/ui/commands.d.ts
@@ -25,7 +25,8 @@ declare namespace Cypress {
          * Custom command to select DOM element by data-testid attribute.
          * @example cy.dataTestId("admin-portal-switch")
          */
-        dataTestId(value: string): Chainable<Element>;
+        dataTestId(value: string, options?: Partial<Cypress.Loggable & Cypress.Timeoutable
+            & Cypress.Withinable & Cypress.Shadow>): Chainable<Element>;
 
         /**
          * Custom command to log users to portals.

--- a/types/ui/commands.d.ts
+++ b/types/ui/commands.d.ts
@@ -41,6 +41,6 @@ declare namespace Cypress {
         /**
          * Custom command to navigate to the user management section.
          */
-        navigateToUserManagement(): Cypress.CanReturnChainable;
+        navigateToUserManagement(switchPortalTab?: boolean): Cypress.CanReturnChainable;
     }
 }

--- a/types/ui/commands.d.ts
+++ b/types/ui/commands.d.ts
@@ -36,11 +36,11 @@ declare namespace Cypress {
         /**
          * Custom command to log users out from portals.
          */
-        logout(waitTime?: number): Chainable<Element>;
+        logout(waitTime?: number): Cypress.CanReturnChainable;
 
         /**
          * Custom command to navigate to the user management section.
          */
-        navigateToUserManagement(switchPortalTab?: boolean): Cypress.CanReturnChainable;
+        navigateToUserManagement(): Cypress.CanReturnChainable;
     }
 }


### PR DESCRIPTION
## Purpose
1. Implement abstract class for listing page objects
2. Implement abstract class for wizard page objects
3. Fix command typings

## Goals
To use the abstract classes to implement listing and create wizard page objects.

## Approach

**Usage**

```js
import { ListPage } from "@wso2/identity-cypress-test-base/ui";

export class UsersListPage extends ListPage {
     ...
}
```