### PR TITLE
Add new `cy.dataComponentId` command & Deprecate `cy.dataTestId`.

### DIFF
--- a/src/ui/commands/dom.ts
+++ b/src/ui/commands/dom.ts
@@ -36,3 +36,19 @@ Cypress.Commands.add("dataTestId", (value: string, options?: Partial<Cypress.Log
 
     return cy.get(CommonUtils.resolveDataTestId(value), options);
 });
+
+/**
+ * Custom command to select DOM element by `data-componentid` attribute.
+ *
+ * @example
+ *    cy.dataComponentId("<RAW_TEST_ID>") -> [data-componentid=<RAW_TEST_ID>]
+ *
+ * @param {string} value - Attribute value.
+ * @param {string} options - Attribute value.
+ * @returns {Cypress.CanReturnChainable}
+ */
+Cypress.Commands.add("dataComponentId", (value: string, options?: Partial<Cypress.Loggable & Cypress.Timeoutable
+    & Cypress.Withinable & Cypress.Shadow>): Cypress.CanReturnChainable => {
+
+    return cy.get(CommonUtils.resolveDataTestId(value), options);
+});

--- a/src/ui/commands/dom.ts
+++ b/src/ui/commands/dom.ts
@@ -30,7 +30,7 @@ import { CommonUtils } from "../utils";
  *    cy.dataTestId("<RAW_TEST_ID>") -> [data-testid=<RAW_TEST_ID>]
  *
  * @param {string} value - Attribute value.
- * @param {string} options - Attribute value.
+ * @param {string} options - Query options. i.e timeout etc.
  * @returns {Cypress.CanReturnChainable}
  */
 Cypress.Commands.add("dataTestId", (value: string, options?: Partial<Cypress.Loggable & Cypress.Timeoutable
@@ -46,7 +46,7 @@ Cypress.Commands.add("dataTestId", (value: string, options?: Partial<Cypress.Log
  *    cy.dataComponentId("<RAW_TEST_ID>") -> [data-componentid=<RAW_TEST_ID>]
  *
  * @param {string} value - Attribute value.
- * @param {string} options - Attribute value.
+ * @param {string} options - Query options. i.e timeout etc.
  * @returns {Cypress.CanReturnChainable}
  */
 Cypress.Commands.add("dataComponentId", (value: string, options?: Partial<Cypress.Loggable & Cypress.Timeoutable

--- a/src/ui/commands/dom.ts
+++ b/src/ui/commands/dom.ts
@@ -22,7 +22,9 @@ import { CommonUtils } from "../utils";
 /// <reference types="cypress" />
 
 /**
- * Custom command to select DOM element by data-testid attribute.
+ * Custom command to select DOM element by `data-testid` attribute.
+ *
+ * @deprecated Deprecated since version 0.2.5. Use `cy.dataComponentId()` instead.
  *
  * @example
  *    cy.dataTestId("<RAW_TEST_ID>") -> [data-testid=<RAW_TEST_ID>]

--- a/src/ui/constants/console/console-header-dom-constants.ts
+++ b/src/ui/constants/console/console-header-dom-constants.ts
@@ -24,16 +24,6 @@ import { HeaderDomConstants } from "../common";
  */
 export class ConsoleHeaderDomConstants extends HeaderDomConstants {
 
-    /**
-     * Private constructor to avoid object instantiation from outside
-     * the class.
-     *
-     * @hideconstructor
-     */
-    private constructor() {
-        super();
-    }
-
     public static readonly MANAGE_SWITCH_DATA_ATTR: string = "app-header-admin-portal-switch";
     public static readonly DEVELOP_SWITCH_DATA_ATTR: string = "app-header-developer-portal-switch";
 }

--- a/src/ui/constants/console/console-side-panel-dom-constants.ts
+++ b/src/ui/constants/console/console-side-panel-dom-constants.ts
@@ -21,14 +21,6 @@
  */
 export class ConsoleSidePanelDomConstants {
 
-    /**
-     * Private constructor to avoid object instantiation from outside
-     * the class.
-     *
-     * @hideconstructor
-     */
-    private constructor() { }
-
     // Develop Features
     public static readonly APPLICATIONS_MENU_ITEM_DATA_ATTR: string = "side-panel-items-applications";
     public static readonly IDP_MENU_ITEM_DATA_ATTR: string = "side-panel-items-identity-providers";
@@ -39,7 +31,7 @@ export class ConsoleSidePanelDomConstants {
     public static readonly ROLES_MENU_ITEM_DATA_ATTR: string = "side-panel-items-roles";
     public static readonly USERSTORES_MENU_ITEM_DATA_ATTR: string = "side-panel-items-user-stores";
     public static readonly CERTIFICATES_MENU_ITEM_DATA_ATTR: string = "side-panel-items-certificates";
-    public static readonly ATTRIBUTES_MENU_ITEM_DATA_ATTR: string = "side-panel-items-local-attributes";
+    public static readonly ATTRIBUTES_MENU_ITEM_DATA_ATTR: string = "side-panel-items-attribute-dialects";
     public static readonly DIALECTS_MENU_ITEM_DATA_ATTR: string = "side-panel-items-local-dialects";
     public static readonly OIDC_SCOPES_MENU_ITEM_DATA_ATTR: string = "side-panel-items-oidc-scopes";
     public static readonly EMAIL_TEMPLATES_MENU_ITEM_DATA_ATTR: string = "side-panel-items-email-templates";

--- a/src/ui/constants/server-constants.ts
+++ b/src/ui/constants/server-constants.ts
@@ -22,15 +22,5 @@
  */
 export class ServerConstants {
 
-    /**
-     * Private constructor to avoid object instantiation from outside
-     * the class.
-     *
-     * @hideconstructor
-     */
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
-    private constructor() {
-    }
-
     public static readonly SESSION_COOKIES: string[] = [ "atbv", "commonAuthId", "JSESSIONID", "opbs" ];
 }

--- a/src/ui/constants/side-panel-dom-constants.ts
+++ b/src/ui/constants/side-panel-dom-constants.ts
@@ -22,14 +22,6 @@
  */
 export class SidePanelDomConstants {
 
-    /**
-     * Private constructor to avoid object instantiation from outside
-     * the class.
-     *
-     * @hideconstructor
-     */
-    private constructor() { }
-
     // Develop Features
     public static readonly APPLICATIONS_PARENT_ITEM_DATA_ATTR: string = "side-panel-items-applications";
     public static readonly IDP_PARENT_ITEM_DATA_ATTR: string = "side-panel-items-identity-providers";

--- a/src/ui/utils/common-utils.ts
+++ b/src/ui/utils/common-utils.ts
@@ -34,6 +34,9 @@ export class CommonUtils {
 
     /**
      * Resolves the data test id when a raw attribute value is passed in.
+     *
+     * @deprecated Deprecated since version 0.2.5. Use `dataComponentId` instead.
+     *
      * @example CommonUtils.resolveDataTestId("sample-id") -> [data-testid="sample-id"]
      *
      * @param {string} value - Attribute value.

--- a/src/ui/utils/common-utils.ts
+++ b/src/ui/utils/common-utils.ts
@@ -44,6 +44,18 @@ export class CommonUtils {
     }
 
     /**
+     * Resolves the data component id when a raw attribute value is passed in.
+     *
+     * @example CommonUtils.resolveDataComponentId("sample-id") -> [data-componentid="sample-id"]
+     *
+     * @param {string} value - Attribute value.
+     * @returns {string}
+     */
+    public static resolveDataComponentId(value: string): string {
+        return `[data-componentid=${ value }]`;
+    }
+
+    /**
      * Perform a click action on the given element.
      *
      * @example

--- a/types/ui/commands.d.ts
+++ b/types/ui/commands.d.ts
@@ -22,8 +22,9 @@
 declare namespace Cypress {
     interface Chainable {
         /**
-         * Custom command to select DOM element by data-testid attribute.
+         * Custom command to select DOM element by `data-testid` attribute.
          * @example cy.dataTestId("admin-portal-switch")
+         * @deprecated Deprecated since version 0.2.5. Use `cy.dataComponentId()` instead.
          */
         dataTestId(value: string, options?: Partial<Cypress.Loggable & Cypress.Timeoutable
             & Cypress.Withinable & Cypress.Shadow>): Chainable<Element>;

--- a/types/ui/commands.d.ts
+++ b/types/ui/commands.d.ts
@@ -29,6 +29,13 @@ declare namespace Cypress {
             & Cypress.Withinable & Cypress.Shadow>): Chainable<Element>;
 
         /**
+         * Custom command to select DOM element by `data-componentid` attribute.
+         * @example cy.dataTestId("admin-portal-switch")
+         */
+        dataComponentId(value: string, options?: Partial<Cypress.Loggable & Cypress.Timeoutable
+            & Cypress.Withinable & Cypress.Shadow>): Chainable<Element>;
+
+        /**
          * Custom command to log users to portals.
          */
         login(username: string, password: string, serverURL: string, portal: string,


### PR DESCRIPTION
## Purpose
A new component identifier ([`data-componentid`](https://github.com/wso2/identity-apps/blob/v1.2.500/modules/core/src/models/core.ts#L119)) was introduced to identity-apps and the existing ([`data-testid`](https://github.com/wso2/identity-apps/blob/v1.2.500/modules/core/src/models/core.ts#L109)) was deprecated as a result. So the `cy.dataTestId` command should also be deprecated and a new command should be introduced to support the new identifier.

## Goals
This PR introduces a new command `cy.dataComponentId` and deprecates the existing `cy.dataTestId`.

## Approach
- Add new command to query `data-componentid` attr.
- Deprecated the existing `cy.dataTestId` command.
